### PR TITLE
Implement delegated settings so groups can have Draw.io admin rights assigned.

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -71,8 +71,11 @@ class SettingsController extends Controller
         return new TemplateResponse($this->appName, "settings", $data, "blank");
     }
 
-
-
+	/**
+	 * Save settings
+	 *
+	 * @AuthorizedAdminSetting(settings=OCA\Drawio\Settings\Admin)
+	 */
     public function settings()
     {
         $drawio = trim($_POST['drawioUrl']);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -11,15 +11,25 @@
 
 namespace OCA\Drawio\Settings;
 
-use OCP\Settings\ISettings;
+use OCP\Settings\IDelegatedSettings;
 
 use OCA\Drawio\AppInfo\Application;
 
 
-class Admin implements ISettings {
+class Admin implements IDelegatedSettings {
 
     public function __construct()
     {
+    }
+
+    public function getName(): ?string {
+        return null;
+    }
+
+    public function getAuthorizedAppConfig(): array {
+        return [
+            'drawio' => ['/drawio.*/'],
+        ];
     }
 
     public function getForm()


### PR DESCRIPTION
This closes #64.

After this change, Draw.io will show up in the "Administration privileges" list where you can add one or more user groups which are allowed to access the Draw.io admin settings:

![image](https://github.com/jgraph/drawio-nextcloud/assets/6613614/d0e6e23d-7db6-4ad5-be90-31b9d7f9cee7)

Users which are member of that group will then see the Draw.io admin settings as part of their personal settings:

![image](https://github.com/jgraph/drawio-nextcloud/assets/6613614/361ef5b0-72cf-4025-9617-0df31475f906)
