### PR TITLE
feat: add mimetypes to nextcloud core

### DIFF
--- a/lib/Migration/RegisterMimeType.php
+++ b/lib/Migration/RegisterMimeType.php
@@ -47,21 +47,6 @@ class RegisterMimeType extends MimeTypeMigration
         $this->appendToFile($mimetypemappingFile, ['drawio' => ['application/x-drawio'], 'dwb' => ['application/x-drawio-wb']]);
     }
 
-    private function copyIcons()
-    {
-        $icons = ['drawio', 'dwb'];
-
-        foreach ($icons as $icon) 
-        {
-            $source = __DIR__ . '/../../img/' . $icon . '.svg';
-            $target = \OC::$SERVERROOT . '/core/img/filetypes/' . $icon . '.svg';
-            if (!file_exists($target) || md5_file($target) !== md5_file($source)) 
-            {
-                copy($source, $target);
-            }
-        }
-    }
-
     public function run(IOutput $output)
     {
         $output->info('Registering the mimetype...');
@@ -73,9 +58,6 @@ class RegisterMimeType extends MimeTypeMigration
         $this->registerForNewFiles();
 
         $output->info('The mimetype was successfully registered.');
-
-        $output->info('Copy drawio icons to core/img directory.');
-        $this->copyIcons();
 
         $this->updateJS->run(new StringInput(''), new ConsoleOutput());
     }


### PR DESCRIPTION
Fixes: #26

I've opened a [PR](https://github.com/nextcloud/server/pull/46729) for nextcloud server which adds the drawio mimetypes upstream to prevent code signing errors.

The above issue was locked to collaborators due to excessive "+1" posts, but this stopped the implementation conversation as well.

This PR prevents the installer from copying the SVG mimetype icons.

## TODO

Where in the code does the `core/js/mimetypelist.js` file get manipulated? I'm not familiar with the nextcloud interfaces, but that will need to be removed as well.