### PR TITLE
fix: replace ILogger with LoggerInterface

### DIFF
--- a/lib/AppConfig.php
+++ b/lib/AppConfig.php
@@ -12,8 +12,7 @@
 namespace OCA\Drawio;
 
 use OCP\IConfig;
-use OCP\ILogger;
-
+use Psr\Log\LoggerInterface;
 
 class AppConfig {
 
@@ -48,7 +47,7 @@ class AppConfig {
         $this->appName = $AppName;
 
         $this->config = \OC::$server->getConfig();
-        $this->logger = \OC::$server->getLogger();
+        $this->logger = \OC::$server->get(LoggerInterface::class);
     }
 
     public function SetDrawioUrl($drawio)

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -27,6 +27,8 @@ use OCA\Drawio\Listeners\FileDeleteListener;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\IAppData;
+use Psr\Log\LoggerInterface;
+
 
 class Application extends App {
 
@@ -73,7 +75,7 @@ class Application extends App {
 
         $container->registerService("Logger", function($c)
         {
-            return $c->query("ServerContainer")->getLogger();
+            return $c->query("ServerContainer")->get(LoggerInterface::class);
         });
 
 

--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -23,13 +23,14 @@ use OCP\Constants;
 use OCP\Files\FileInfo;
 use OCP\Files\IRootFolder;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
 use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUserSession;
 use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Share\IManager;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 use OC\Files\Filesystem;
 use OC\Files\View;
@@ -100,7 +101,7 @@ class EditorController extends Controller
      * @param IUserSession $userSession - current user session
      * @param IURLGenerator $urlGenerator - url generator service
      * @param IL10N $trans - l10n service
-     * @param ILogger $logger - logger
+     * @param LoggerInterface $logger - logger
      * @param OCA\Drawio\AppConfig $config - app config
      */
     public function __construct($AppName,
@@ -109,7 +110,7 @@ class EditorController extends Controller
                                 IUserSession $userSession,
                                 IURLGenerator $urlGenerator,
                                 IL10N $trans,
-                                ILogger $logger,
+                                LoggerInterface $logger,
                                 AppConfig $config,
                                 IManager $shareManager,
                                 ISession $session,
@@ -178,7 +179,7 @@ class EditorController extends Controller
         {
             return $this->loadInternal($fileId, null, true);
 		} catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Can't load file version: $fileId, $revId", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't load file version: $fileId, $revId", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
 			$message = (string)$this->trans->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -225,7 +226,7 @@ class EditorController extends Controller
 				return new DataResponse(['message' => (string)$this->trans->t('Invalid fileId supplied.')], Http::STATUS_BAD_REQUEST);
 			}
 		} catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Can't get file versions: $fileId", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't get file versions: $fileId", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
 			$message = (string)$this->trans->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -314,7 +315,7 @@ class EditorController extends Controller
 			$message = (string)$e->getHint();
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		} catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Can't load file: $fileId , $shareToken", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't load file: $fileId , $shareToken", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
 			$message = (string)$this->trans->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -382,7 +383,7 @@ class EditorController extends Controller
 			$message = (string)$e->getHint();
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		} catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Can't get file info: $fileId , $shareToken", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't get file info: $fileId , $shareToken", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
 			$message = (string)$this->trans->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -486,7 +487,7 @@ class EditorController extends Controller
 			$message = (string)$e->getHint();
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		} catch (\Exception $e) {
-            $this->logger->logException($e, ["message" => "Can't save file: $fileId , $shareToken", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't save file: $fileId , $shareToken", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
 			$message = (string)$this->trans->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -539,7 +540,7 @@ class EditorController extends Controller
         }
         catch (\Exception $e) 
         {
-            $this->logger->logException($e, ["message" => "Can't save preview for file: $fileId , $shareToken", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't save preview for file: $fileId , $shareToken", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
 			$message = (string)$this->trans->t('An internal server error occurred.');
 			return new DataResponse(['message' => $message], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
@@ -576,7 +577,7 @@ class EditorController extends Controller
         }
         catch (NotPermittedException $e)
         {
-            $this->logger->logException($e, ["message" => "Can't create file: $name", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't create file: $name", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
             return ["error" => $this->trans->t("Can't create file")];
         }
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -15,8 +15,9 @@ namespace OCA\Drawio\Controller;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IL10N;
-use OCP\ILogger;
 use OCP\IRequest;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 use OCA\Drawio\AppConfig;
 use OCA\Drawio\Migration;
@@ -33,13 +34,13 @@ class SettingsController extends Controller
      * @param string $AppName - application name
      * @param IRequest $request - request object
      * @param IL10N $trans - l10n service
-     * @param ILogger $logger - logger
+     * @param LoggerInterface $logger - logger
      * @param OCA\Drawio\AppConfig $config - application configuration
      */
     public function __construct($AppName,
                                 IRequest $request,
                                 IL10N $trans,
-                                ILogger $logger,
+                                LoggerInterface $logger,
                                 AppConfig $config
                                 )
     {

--- a/lib/Listeners/FileDeleteListener.php
+++ b/lib/Listeners/FileDeleteListener.php
@@ -8,17 +8,18 @@ use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\Files\Folder;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
-use OCP\ILogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 class FileDeleteListener implements IEventListener {
 
-    /** @var ILogger */
+    /** @var LoggerInterface */
     private $logger;
 
     /** @var IAppData */
     private $appData;
 
-	public function __construct(ILogger $logger, IAppData $appData)
+	public function __construct(LoggerInterface $logger, IAppData $appData)
     {
         $this->logger = $logger;
         $this->appData = $appData;
@@ -47,7 +48,7 @@ class FileDeleteListener implements IEventListener {
         catch (\Exception $e)
         {
             // ignore
-            $this->logger->logException($e, ["message" => "Can't delete preview for file: " . $node->getPath(), "app" => 'drawio']);
+            $this->logger->error($e->getMessage(), ["message" => "Can't delete preview for file: " . $node->getPath(), "app" => 'drawio', 'level' => LogLevel::ERROR, 'exception' => $e]);
         }
 	}
 }

--- a/lib/Preview/DrawioPreview.php
+++ b/lib/Preview/DrawioPreview.php
@@ -9,8 +9,9 @@ use OCP\AppFramework\QueryException;
 use OCP\Files\FileInfo;
 use OCP\Files\IAppData;
 use OCP\Files\NotFoundException;
-use OCP\ILogger;
 use OCP\Image;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 
 use OCA\Drawio\AppConfig;
 
@@ -32,7 +33,7 @@ class DrawioPreview extends Provider
         "application/x-drawio-wb"
     ];
 
-    public function __construct(ILogger $logger, IAppData $appData)
+    public function __construct(LoggerInterface $logger, IAppData $appData)
     {
         $this->logger = $logger;
         $this->appData = $appData;
@@ -101,7 +102,7 @@ class DrawioPreview extends Provider
         }
         catch (\Exception $e)
         {
-            $this->logger->logException($e, ["message" => "Can't get preview file", "app" => $this->appName]);
+            $this->logger->error($e->getMessage(), ["message" => "Can't get preview file", "app" => $this->appName, 'level' => LogLevel::ERROR, 'exception' => $e]);
             return false;
         }
     }


### PR DESCRIPTION
This replaces the long deprecated and now removed ILogger with LoggerInterface as done in
https://github.com/nextcloud/server/pull/40145.

This fixes #90