### PR TITLE
fix: Get the sharing token the new way

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@nextcloud/files": "^3.0.0",
         "@nextcloud/l10n": "^2.2.0",
         "@nextcloud/router": "^2.1.2",
+	"@nextcloud/sharing": "^0.2.3",
         "jquery": "^3.7.0",
         "path": "^0.12.7",
         "process": "^0.11.10"

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@
  **/
 
 import { generateUrl } from '@nextcloud/router'
+import { getSharingToken } from '@nextcloud/sharing/public'
 import * as $ from 'jquery';
 import { translate as t } from '@nextcloud/l10n'
 import { showError } from '@nextcloud/dialogs'
@@ -159,7 +160,7 @@ OCA.DrawIO = {
         {
             var fileName = $('#filename').val();
             var mimeType = $('#mimetype').val();
-            var sharingToken = $('#sharingToken').val();
+            var sharingToken = getSharingToken();
             var extension = fileName.substr(fileName.lastIndexOf('.') + 1).toLowerCase();
             var isWB = String(extension == 'dwb');
 


### PR DESCRIPTION
NC 31 does not provide the sharing token in an invisible HTML element anymore. This fixes this issue by using the path of the richdocuments plugin here:
https://github.com/nextcloud/richdocuments/pull/4030/files

This refers to #90

I have not tested the change because I have no setup to compile the minified JS here!