### PR TITLE
fix: get public share flag from inital state

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,7 +8,7 @@
  **/
 
 import { generateUrl } from '@nextcloud/router'
-import { getSharingToken } from '@nextcloud/sharing/public'
+import { getSharingToken, isPublicShare } from '@nextcloud/sharing/public'
 import * as $ from 'jquery';
 import { translate as t } from '@nextcloud/l10n'
 import { showError } from '@nextcloud/dialogs'
@@ -156,7 +156,7 @@ OCA.DrawIO = {
 
     init: async function () 
     {
-        if ($('#isPublic').val() === '1' && !$('#filestable').length) 
+        if (isPublicShare() && !$('#filestable').length)
         {
             var fileName = $('#filename').val();
             var mimeType = $('#mimetype').val();


### PR DESCRIPTION
This is a follow-up to #92. It seems that not only the sharing token but also the information if it is a public share is now in the initial state only.

See also https://docs.nextcloud.com/server/latest/developer_manual/app_publishing_maintenance/app_upgrade_guide/upgrade_to_31.html#files-and-files-sharing

This fixes #97