### PR TITLE
fix: migrate to the initial state api

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -154,17 +154,35 @@ OCA.DrawIO = {
         }
     },
 
+    isViewIsFile = function() {
+        const mimetype = document.getElementById('mimetype')?.value
+        if (mimetype !== undefined) {
+            return mimetype !== 'httpd/unix-directory';
+        }
+        
+        try {
+            return loadState('files_sharing', 'view') === 'public-file-share';
+        } catch {
+            return false;
+        }
+    },
+
     init: async function () 
     {
-        if (isPublicShare() && !$('#filestable').length)
+        if (isPublicShare() && OCA.DrawIO.isViewIsFile())
         {
-            var fileName = $('#filename').val();
-            var mimeType = $('#mimetype').val();
+
+            var fileName = document.getElementById('filename')?.value ?? loadState('files_sharing', 'filename', null);
             var sharingToken = getSharingToken();
+
+	    if (fileName === null || fileName === undefined) {
+		return;
+	    }
+
             var extension = fileName.substr(fileName.lastIndexOf('.') + 1).toLowerCase();
             var isWB = String(extension == 'dwb');
 
-            if (!OCA.DrawIO.Mimes[extension] || OCA.DrawIO.Mimes[extension].mime != mimeType)
+            if (!OCA.DrawIO.Mimes[extension])
             {
                 return;
             }


### PR DESCRIPTION
This hopefully restores the public preview function in NC 31+

Ii uses the initial state API like the onlyoffice plugin does here: 
https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/4388571e41e3f69ba503dedf14a075b713350049/src/main.js#L816
and here:
https://github.com/ONLYOFFICE/onlyoffice-nextcloud/blob/4388571e41e3f69ba503dedf14a075b713350049/src/main.js#L832C1-L833C1

I couldn't find a proper way to get the MIME type via this approach, so we rely on the extension for now. I haven't tested it yet, but it should not break anything that's currently broken anyway.