### PR TITLE
fix issue 114. get $share when loggedIn

### DIFF
--- a/lib/Controller/EditorController.php
+++ b/lib/Controller/EditorController.php
@@ -753,12 +753,17 @@ class EditorController extends Controller
         $file = null;
         $writeable = false;
         $baseFolder = null;
+        $share = null;
 
         if (!empty($fileId) && $this->userSession->isLoggedIn()) 
         {
             $file = $this->getFileById($fileId);
             $uid = $this->userSession->getUser()->getUID();
             $baseFolder = $this->root->getUserFolder($uid);
+            if (!empty($shareToken))
+            {
+                $share = $this->shareManager->getShareByToken($shareToken);  // Have fileId and shareToken, and be logged in, get $share
+            }
         }
         else if (!empty($shareToken))
         {


### PR DESCRIPTION
fix [issue 114](https://github.com/jgraph/drawio-nextcloud/issues/114). error：

>  Call to a member function getPermissions() on null in file '/var/www/myserver.example/apps/drawio/lib/Controller/EditorController.php' line 856

When the user is logged in and both fileId and shareToken are not empty, the $share variable should also be retrieved to prevent null pointer issues.
