### PR TITLE
Load JS as Init Script

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -50,7 +50,7 @@ class Application extends App {
             if (isset($url)) {
                 if (preg_match("%/apps/files(/.*)?%", $url) || preg_match("%/s/.*%", $url)) // Files app and file sharing
                 {
-                    Util::addScript($appName, "main");
+                    Util::addInitScript($appName, "main");
                     Util::addStyle($appName, "main");
                 }
             }


### PR DESCRIPTION
Fix https://github.com/jgraph/drawio-nextcloud/issues/106

Loading the JS via addInitScript instead of addScript. On my test machine, this fixes the problem in issue 106.

PS: I'm not very familiar with Github, so I hope this is correct. I only changed this one function call in lib/AppInfo/Application.php.